### PR TITLE
do not gc dirs with .box, do not test deleted branches

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -2,7 +2,7 @@
  * routes/index.js
  */
 
-var BASE_PATH = "../lib/"
+var BASE_PATH = "../lib/";
 
 var _ = require('underscore')
   , Step = require('step')
@@ -250,6 +250,10 @@ function handleWebhook(repo, user, payload) {
   var github_commit_info = gh.webhook_extract_latest_commit_info(payload);
   var repo_ssh_url;
   var repo_metadata;
+  // don't test: deleted branches
+  if (payload.deleted === true) {
+    return;
+  }
   if (user.github.id) {
     repo_metadata = _.find(user.github_metadata[user.github.id].repos, function(item) {
       return repo.url == item.html_url.toLowerCase();

--- a/util/gc.py
+++ b/util/gc.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# Garbage collection script for strider.
+#
 
 import os
 import shutil
@@ -16,15 +18,18 @@ while True:
     if os.path.isdir(os.path.join(ROOT_DIR, user)):
       for branch in os.listdir(os.path.join(ROOT_DIR, user)):
         path = os.path.join(ROOT_DIR,user,branch)
-        info = os.stat(path)
-        dirs.append((path,info))
+        if not os.path.exists(os.path.join(path, '.box')):
+          info = os.stat(path)
+          dirs.append((path,info))
+        else:
+          print '%s: found .box, skipping.' % path
   dirs.sort(key = lambda d: d[1].st_mtime)
 
   print 'Cache directory count: ', len(dirs)
 
   def get_free():
-	  stats = os.statvfs(ROOT_DIR)
-	  return stats.f_bavail * stats.f_bsize / pow(1024,3)
+    stats = os.statvfs(ROOT_DIR)
+    return stats.f_bavail * stats.f_bsize / pow(1024,3)
 
   while get_free() < FREE_TARGET_GB and len(dirs) > 0:
     print 'Free space (GB): %s < Target (GB): %s ' % (get_free(), FREE_TARGET_GB)


### PR DESCRIPTION
@d3ming - this will prevent strider from removing g-box state stored on disk. This has been causing some issues.

In the long term this will be less important when g-box state is stored fully in the cloud.
