### PR TITLE
CD-126 Make strider links public

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -266,11 +266,11 @@ var requireReadAccess = function(req, res, next) {
   // Anonymous user can access a resource which is for a public project
   if (req.user === undefined) {
     User.findOne({"github_config": { "$elemMatch" : {"url":case_insensitive_url, "public":true}}}, function(err, user) {
-      if (err || !user) {
+      /*if (err || !user) {
         console.log("Anonymous user attempted to view " + repo_url + " without authorization.");
         res.statusCode = 404;
         return res.end("not found");
-      }
+      }*/
       req.access_level = 0;
       req.repo_url = repo_url;
       next();

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -265,9 +265,7 @@ var requireReadAccess = function(req, res, next) {
 
   // Anonymous user can access a resource which is for a public project
   if (req.user === undefined) {
-    User.findOne(
-      {"github_config": { "$elemMatch" : {"url":case_insensitive_url, "public":true}}},
-      function(err, user) {
+    User.findOne({"github_config": { "$elemMatch" : {"url":case_insensitive_url, "public":true}}}, function(err, user) {
       if (err || !user) {
         console.log("Anonymous user attempted to view " + repo_url + " without authorization.");
         res.statusCode = 404;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -265,18 +265,20 @@ var requireReadAccess = function(req, res, next) {
 
   // Anonymous user can access a resource which is for a public project
   if (req.user === undefined) {
-    User.findOne({"github_config": { "$elemMatch" : {"url":case_insensitive_url, "public":true}}}, function(err, user) {
+    User.findOne(
+      {"github_config": { "$elemMatch" : {"url":case_insensitive_url, "public":true}}},
+      function(err, user) {
+      if (err || !user) {
+        console.log("Anonymous user attempted to view " + repo_url + " without authorization.");
+        res.statusCode = 404;
+        return res.end("not found");
+      }
       req.access_level = 0;
       req.repo_url = repo_url;
       next();
     })
   } else {
     req.user.get_repo_config(repo_url, function(err, repo, access_level) {
-      if (err || !repo || access_level < 0) {
-        console.log("user '" + req.user.email + "' attempted to view " + repo_url + " without authorization.");
-        res.statusCode = 401;
-        return res.end("not authorized");
-      }
       req.access_level = access_level;
       req.repo_url = repo_url;
       next();

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -266,11 +266,6 @@ var requireReadAccess = function(req, res, next) {
   // Anonymous user can access a resource which is for a public project
   if (req.user === undefined) {
     User.findOne({"github_config": { "$elemMatch" : {"url":case_insensitive_url, "public":true}}}, function(err, user) {
-      /*if (err || !user) {
-        console.log("Anonymous user attempted to view " + repo_url + " without authorization.");
-        res.statusCode = 404;
-        return res.end("not found");
-      }*/
       req.access_level = 0;
       req.repo_url = repo_url;
       next();

--- a/routes/api/jobs.js
+++ b/routes/api/jobs.js
@@ -134,6 +134,9 @@ exports.raw = function(req, res) {
          return err();
        }
        function gotRepo() {
+         if (err || !r) {
+           return error();
+         }
          res.setHeader('Content-type', 'text/plain');
          res.send(job.stdmerged ? filter(job.stdmerged) : '');
        }

--- a/routes/api/jobs.js
+++ b/routes/api/jobs.js
@@ -134,9 +134,9 @@ exports.raw = function(req, res) {
          return err();
        }
        function gotRepo(err, r) {
-         if (err || !r) {
+         /*if (err || !r) {
            return error();
-         }
+         }*/
          res.setHeader('Content-type', 'text/plain');
          res.send(job.stdmerged ? filter(job.stdmerged) : '');
        }

--- a/routes/api/jobs.js
+++ b/routes/api/jobs.js
@@ -133,10 +133,7 @@ exports.raw = function(req, res) {
        if (err || !job) {
          return err();
        }
-       function gotRepo(err, r) {
-         /*if (err || !r) {
-           return error();
-         }*/
+       function gotRepo() {
          res.setHeader('Content-type', 'text/plain');
          res.send(job.stdmerged ? filter(job.stdmerged) : '');
        }

--- a/routes/api/jobs.js
+++ b/routes/api/jobs.js
@@ -122,10 +122,6 @@ exports.jobs_start = function(req, res) {
  * Return the merged output
  */
 exports.raw = function(req, res) {
-  function error() {
-         res.statusCode = 404;
-         return res.send("Job not found");
-  }
 
   Job.findById(req.params.id)
      .lean(true)
@@ -133,10 +129,7 @@ exports.raw = function(req, res) {
        if (err || !job) {
          return err();
        }
-       function gotRepo(err, r) {
-         if (err || !r) {
-           return error();
-         }
+       function gotRepo() {
          res.setHeader('Content-type', 'text/plain');
          res.send(job.stdmerged ? filter(job.stdmerged) : '');
        }

--- a/routes/api/jobs.js
+++ b/routes/api/jobs.js
@@ -122,7 +122,7 @@ exports.jobs_start = function(req, res) {
  * Return the merged output
  */
 exports.raw = function(req, res) {
-  function err() {
+  function error() {
          res.statusCode = 404;
          return res.send("Job not found");
   }
@@ -135,7 +135,7 @@ exports.raw = function(req, res) {
        }
        function gotRepo(err, r) {
          if (err || !r) {
-           return err();
+           return error();
          }
          res.setHeader('Content-type', 'text/plain');
          res.send(job.stdmerged ? filter(job.stdmerged) : '');

--- a/routes/api/jobs.js
+++ b/routes/api/jobs.js
@@ -133,7 +133,7 @@ exports.raw = function(req, res) {
        if (err || !job) {
          return err();
        }
-       function gotRepo() {
+       function gotRepo(err, r) {
          if (err || !r) {
            return error();
          }


### PR DESCRIPTION
Make strider not check for authentication, this makes the shared links we get on our git commit status and hipchat notifications public (still require them to be logged in to strider though).   @vasili-zolotov 

Also fix an issue where when I make an unauthenticated API call for GET /api/job/:id, we get the following callstack:

TypeError: object is not a function
    at Promise.gotRepo (/home/ubuntu/src/strider/routes/api/jobs.js:138:19)
    at Promise.<anonymous> (/home/ubuntu/src/strider/node_modules/mongoose/node_modules/mpromise/lib/promise.js:162:8)
    at Promise.EventEmitter.emit (events.js:95:17)
    at Promise.emit (/home/ubuntu/src/strider/node_modules/mongoose/node_modules/mpromise/lib/promise.js:79:38)
    at Promise.fulfill (/home/ubuntu/src/strider/node_modules/mongoose/node_modules/mpromise/lib/promise.js:92:20)
    at /home/ubuntu/src/strider/node_modules/mongoose/lib/query.js:1794:30
    at /home/ubuntu/src/strider/node_modules/mongoose/lib/utils.js:414:16
    at /home/ubuntu/src/strider/node_modules/mongoose/node_modules/mongodb/lib/mongodb/collection.js:953:5
    at /home/ubuntu/src/strider/node_modules/mongoose/node_modules/mongodb/lib/mongodb/cursor.js:683:35
    at Cursor.close (/home/ubuntu/src/strider/node_modules/mongoose/node_modules/mongodb/lib/mongodb/cursor.js:903:5)
