### PR TITLE
CD-116 Make strider GC script keep a higher limit

### DIFF
--- a/util/gc.py
+++ b/util/gc.py
@@ -8,7 +8,7 @@ import commands
 import time
 from sys import stdout
 
-FREE_TARGET_GB = 50
+FREE_TARGET_GB = 100
 ROOT_DIR = '/home/strider/.strider'
 
 

--- a/util/gc.py
+++ b/util/gc.py
@@ -46,5 +46,7 @@ while True:
     print 'Vagrant: ', output
     shutil.rmtree(path)
 
-  stdout.flush()  
-  time.sleep(300)
+  stdout.flush()
+
+  # Run at most once every 3H
+  time.sleep(10800)


### PR DESCRIPTION
@vasili-zolotov Strider dir currently takes 222GB, I think we could free up another 50GB from that and keep a more aggressive cleaning policy on stopped AWS machines.  Thoughts?
