### PR TITLE
Update strider-python plugin to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "strider-env": "~0.2.0",
     "pw": "0.0.4",
     "strider-sauce": "~0.4.0",
-    "strider-python": "0.0.2",
+    "strider-python": "0.2.0",
     "strider-custom": "~0.3.1",
     "connect": "~2.7.3",
     "express": "~3.1.0",


### PR DESCRIPTION
The old version (0.0.2) runs afoul of
https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1115466 with
its vendored virtualenv.

0.2.1 is newer but doesn't seem to work: it references the vendored
virtualenv.py, but doesn't actually install it. 0.2.3 is tagged on
github but not in npm's repository.
